### PR TITLE
Poulpe-528 Issue with incorrect sid after DB clean

### DIFF
--- a/poulpe-model/src/main/java/org/jtalks/poulpe/model/entity/PoulpeUser.java
+++ b/poulpe-model/src/main/java/org/jtalks/poulpe/model/entity/PoulpeUser.java
@@ -17,11 +17,17 @@ package org.jtalks.poulpe.model.entity;
 import org.hibernate.validator.constraints.Length;
 import org.jtalks.common.model.entity.Group;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 
 /**
  * Stores information about the user.
  */
 public class PoulpeUser extends org.jtalks.common.model.entity.User {
+
+    private static final long serialVersionUID = 7200307258941749787L;
 
     /**
      * Creates an empty and <i>not valid</i> instance without required fields, use {@link #PoulpeUser(String, String,
@@ -88,4 +94,44 @@ public class PoulpeUser extends org.jtalks.common.model.entity.User {
         return "PoulpeUser [id=" + getId() + ", email=" + getEmail() + ", username=" + getUsername() + "]";
     }
 
+    /**
+     * Customized deserialization of the fields {@link org.jtalks.common.model.entity.Entity#id},
+     * {@link org.jtalks.common.model.entity.Entity#uuid}
+     *
+     * Note: The {@link org.jtalks.common.model.entity.User#groups} is marked as transient and will not be serialized
+     * (for more details pls. see at <a href="http://jira.jtalks.org/browse/POULPE-528">JIRA</a>).
+     *
+     * @serialData  {@link org.jtalks.common.model.entity.Entity#id}, {@link org.jtalks.common.model.entity.Entity#uuid}
+     *              and the hole entity {@link org.jtalks.common.model.entity.User},
+     *              expect for the transient field {@link org.jtalks.common.model.entity.User#groups}
+     * @param s
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {
+        s.defaultReadObject();
+        long id = s.readLong();
+        String uuid = (String)s.readObject();
+        setId(id);
+        setUuid(uuid);
+    }
+
+    /**
+     * Customized serialization of the fields {@link org.jtalks.common.model.entity.Entity#id},
+     * {@link org.jtalks.common.model.entity.Entity#uuid}
+     *
+     * Note: The {@link org.jtalks.common.model.entity.User#groups} is marked as transient and will not be serialized
+     * (for more details pls. see at <a href="http://jira.jtalks.org/browse/POULPE-528">JIRA</a>).
+     *
+     * @serialData  {@link org.jtalks.common.model.entity.Entity#id}, {@link org.jtalks.common.model.entity.Entity#uuid}
+     *              and the hole entity {@link org.jtalks.common.model.entity.User},
+     *              expect for the transient field {@link org.jtalks.common.model.entity.User#groups}
+     * @param s
+     * @throws IOException
+     */
+    private void writeObject(ObjectOutputStream s) throws IOException {
+        s.defaultWriteObject();
+        s.writeLong(getId());
+        s.writeObject(getUuid());
+    }
 }

--- a/poulpe-model/src/test/java/org/jtalks/poulpe/model/entity/PoulpeUserTest.java
+++ b/poulpe-model/src/test/java/org/jtalks/poulpe/model/entity/PoulpeUserTest.java
@@ -1,11 +1,18 @@
 package org.jtalks.poulpe.model.entity;
 
 import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
 import org.jtalks.common.model.entity.Group;
+import org.jtalks.common.model.entity.User;
+import org.springframework.util.SerializationUtils;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.testng.Assert.*;
+import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
 
 /**
  * @author stanislav bashkirtsev
@@ -31,4 +38,38 @@ public class PoulpeUserTest {
         return group;
     }
 
+    @Test
+    public void theEntityFieldsShouldBeSerialized() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        PoulpeUser user = new PoulpeUser("username","email","password","salt");
+        user.setId(1);
+        user.setAvatar(new byte[]{1});
+        user.setVersion(1L);
+        user.setFirstName("First Name");
+        user.setLastName("Last Name");
+        user.setBanReason("Ban Reason");
+        user.setEnabled(true);
+        user.setRole("Role");
+        Method setLastLogin = User.class.getDeclaredMethod("setLastLogin", DateTime.class);
+        Method setEncodedUsername = User.class.getDeclaredMethod("setEncodedUsername", String.class);
+        setLastLogin.setAccessible(true);
+        setEncodedUsername.setAccessible(true);
+        setLastLogin.invoke(user,DateTime.now());
+        setEncodedUsername.invoke(user,"Encoded Username");
+
+        byte[] serialize = SerializationUtils.serialize(user);
+        PoulpeUser serializedUser = (PoulpeUser)SerializationUtils.deserialize(serialize);
+        assertReflectionEquals(user, serializedUser);
+    }
+
+    @Test
+    public void groupsFieldIsNotSerializable(){
+        List<Group> groups = PoulpeGroup.createGroupsWithNames("The Group");
+        PoulpeUser userInGroup = PoulpeUser.withId(1);
+        userInGroup.setGroups(groups);
+
+        byte[] serialize = SerializationUtils.serialize(userInGroup);
+        PoulpeUser serializedUser = (PoulpeUser) SerializationUtils.deserialize(serialize);
+
+        assertNull(serializedUser.getGroups(), "After deserialiation, the transient field `List<Group> groups` must be null");
+    }
 }


### PR DESCRIPTION
We have to customize serialization of the entity PoulpeUser because of we used to loose 'id' data from org.jtalks.common.model.entity.Entity class when saved other User' details in session-storage-file.
Created:
  - methods writeObject(), readObject() and serialVersionUID field.
  - unit-test for checking is most fields of User entity serialized

**Pls. note!** If the PR is ok it can be merged **only after** [this PR](https://github.com/jtalks-org/poulpe/pull/7) has been merged