### PR TITLE
Updates commonVersion to 0.59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -533,7 +533,7 @@
     <springVersion>3.0.5.RELEASE</springVersion>
     <zkVersion>6.0.1.FL.20120413</zkVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <commonVersion>0.57</commonVersion>
+    <commonVersion>0.59</commonVersion>
   </properties>
 
   <distributionManagement>

--- a/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/BranchHibernateDaoTest.java
+++ b/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/BranchHibernateDaoTest.java
@@ -62,6 +62,7 @@ public class BranchHibernateDaoTest extends AbstractTransactionalTestNGSpringCon
     public void testSave() {
         givenParentSection();
         dao.saveOrUpdate(branch);
+        session.flush();
         assertBranchSaved();
         assertGroupSaved();
     }
@@ -131,6 +132,7 @@ public class BranchHibernateDaoTest extends AbstractTransactionalTestNGSpringCon
         branch.setName(newName);
 
         dao.saveOrUpdate(branch);
+        session.flush();
 
         assertBranchNameChanged(newName);
         assertGroupNameChanged(newGroupName);
@@ -152,6 +154,7 @@ public class BranchHibernateDaoTest extends AbstractTransactionalTestNGSpringCon
         givenBranch();
         branch.setName(null);
         dao.saveOrUpdate(branch);
+        session.flush();
     }
 
     @Test

--- a/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/ComponentHibernateDaoTest.java
+++ b/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/ComponentHibernateDaoTest.java
@@ -72,6 +72,7 @@ public class ComponentHibernateDaoTest extends AbstractTransactionalTestNGSpring
     @Test
     public void testSave() {
         dao.saveOrUpdate(forum);
+        session.flush();
         Component actual = ObjectRetriever.retrieveUpdated(forum, session);
         assertReflectionEquals(forum, actual);
     }
@@ -90,6 +91,7 @@ public class ComponentHibernateDaoTest extends AbstractTransactionalTestNGSpring
         session.save(forum);
         forum.setName(newName);
         dao.saveOrUpdate(forum);
+        session.flush();
 
         String actual = ObjectRetriever.retrieveUpdated(forum, session).getName();
         assertEquals(actual, newName);
@@ -152,6 +154,7 @@ public class ComponentHibernateDaoTest extends AbstractTransactionalTestNGSpring
         Collections.shuffle(expected);
 
         dao.saveOrUpdate(forum);
+        session.flush();
 
         forum = ObjectRetriever.retrieveUpdated(forum, session);
         List<PoulpeSection> actual = forum.getSections();

--- a/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/SectionHibernateDaoTest.java
+++ b/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/SectionHibernateDaoTest.java
@@ -65,6 +65,7 @@ public class SectionHibernateDaoTest extends AbstractTransactionalTestNGSpringCo
     @Test
     public void saveSectionTest() {
         dao.saveOrUpdate(section);
+        session.flush();
         assertSectionSaved();
     }
 
@@ -109,6 +110,7 @@ public class SectionHibernateDaoTest extends AbstractTransactionalTestNGSpringCo
         section.setName(newName);
 
         dao.saveOrUpdate(section);
+        session.flush();
         assertNameChanged(newName);
     }
 
@@ -122,6 +124,7 @@ public class SectionHibernateDaoTest extends AbstractTransactionalTestNGSpringCo
         givenSection();
         section.setName(null);
         dao.saveOrUpdate(section);
+        session.flush();
     }
 
     @Test
@@ -160,6 +163,7 @@ public class SectionHibernateDaoTest extends AbstractTransactionalTestNGSpringCo
             Collections.shuffle(expected);
 
             dao.saveOrUpdate(section);
+            session.flush();
 
             section = ObjectRetriever.retrieveUpdated(section, session);
             List<PoulpeBranch> actual = section.getPoulpeBranches();

--- a/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/TopicTypeDaoTest.java
+++ b/poulpe-model/src/test/java/org/jtalks/poulpe/model/dao/hibernate/TopicTypeDaoTest.java
@@ -99,6 +99,7 @@ public class TopicTypeDaoTest extends AbstractTransactionalTestNGSpringContextTe
         String newTitle = "new title";
         topicType.setTitle(newTitle);
         dao.saveOrUpdate(topicType);
+        session.flush();
         session.evict(topicType);
         TopicType result = (TopicType) session.get(TopicType.class, topicType.getId());
 


### PR DESCRIPTION
sets version of jtalks-common up to 0.59 build at maven dependencies.
updates some tests according to changes from jtalks-common 0.58 build. 