### PR TITLE
Migration V23_Change_engine_to_InnoDB

### DIFF
--- a/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V23__Change_engine_to_InnoDB.sql
+++ b/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V23__Change_engine_to_InnoDB.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright (C) 2011  JTalks.org Team
+-- This library is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU Lesser General Public
+-- License as published by the Free Software Foundation; either
+-- version 2.1 of the License, or (at your option) any later version.
+-- This library is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-- Lesser General Public License for more details.
+-- You should have received a copy of the GNU Lesser General Public
+-- License along with this library; if not, write to the Free Software
+-- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+--
+
+# We have to change ENGINE to InnoDB since we have changed charset to UTF8MB4 in jcommune.
+ALTER TABLE `BASE_COMPONENTS` ENGINE=InnoDB;
+ALTER TABLE `DEFAULT_PROPERTIES` ENGINE=InnoDB;
+ALTER TABLE `TOPIC_TYPES` ENGINE=InnoDB;


### PR DESCRIPTION
 - We have to change ENGINE to InnoDB since we have changed charset to UTF8MB4 in jcommune.