### PR TITLE
fixed collation in V7 migration

### DIFF
--- a/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V7__Addin_admin_group_user_component.sql
+++ b/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V7__Addin_admin_group_user_component.sql
@@ -16,6 +16,9 @@
 -- 'FROM COMPONENTS' are not used, but query mast contain 'FROM dual' clause
 --  @see <a href="http://dev.mysql.com">http://dev.mysql.com/doc/refman/5.0/en/select.html/a>.
 
+-- SET NAMES used to avoid Illegal mix of collations error when '=' operator is called
+SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
+
 SET @adminUserName := 'admin';
 SET @passwordHash := '21232f297a57a5a743894a0e4a801fc3';
 SET @adminGroupName := 'Administrators';


### PR DESCRIPTION
 - vars that have different types of collation can not be compared by '=', that's why we need to set default collation for all vars.