### PR TITLE
fixed illegal mix of collations

### DIFF
--- a/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V23__Change_engine_to_InnoDB.sql
+++ b/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V23__Change_engine_to_InnoDB.sql
@@ -13,7 +13,7 @@
 -- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 --
 
-# We have to change ENGINE to InnoDB since we have changed charset to UTF8MB4 in jcommune.
+-- We have to change ENGINE to InnoDB since we have changed charset to UTF8MB4 in jcommune.
 ALTER TABLE `BASE_COMPONENTS` ENGINE=InnoDB;
 ALTER TABLE `DEFAULT_PROPERTIES` ENGINE=InnoDB;
 ALTER TABLE `TOPIC_TYPES` ENGINE=InnoDB;

--- a/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V7__Addin_admin_group_user_component.sql
+++ b/poulpe-model/src/main/resources/org/jtalks/poulpe/migrations/V7__Addin_admin_group_user_component.sql
@@ -16,8 +16,10 @@
 -- 'FROM COMPONENTS' are not used, but query mast contain 'FROM dual' clause
 --  @see <a href="http://dev.mysql.com">http://dev.mysql.com/doc/refman/5.0/en/select.html/a>.
 
--- SET NAMES used to avoid Illegal mix of collations error when '=' operator is called
-SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
+-- vars that have different types of collation can not be compared by '=', that's why we need to set
+-- connection collation the same as database collation in spite of server configuration.
+SET @default_collation_connection = @@collation_connection;
+SET @@collation_connection = @@collation_database;
 
 SET @adminUserName := 'admin';
 SET @passwordHash := '21232f297a57a5a743894a0e4a801fc3';
@@ -99,4 +101,5 @@ INSERT IGNORE INTO acl_entry (acl_object_identity, sid, ace_order, mask, grantin
        (SELECT ae.acl_object_identity, ae.sid FROM acl_entry ae
          WHERE ae.acl_object_identity = @acl_object_identity_id
            AND ae.sid = @acl_sid_id_group);
-
+-- return collation_connection to a previous state.
+SET @@collation_connection = @default_collation_connection;


### PR DESCRIPTION
- vars that have different types of collation can not be compared by '=',
  that's why we need to set connection collation the same as database
  collation in spite of server configuration.