### PR TITLE
JC-2371 Login with empty "Username" field leads to server error.

### DIFF
--- a/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/UserDao.java
+++ b/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/UserDao.java
@@ -67,6 +67,14 @@ public interface UserDao extends org.jtalks.common.model.dao.UserDao<PoulpeUser>
     List<PoulpeUser> getUsersInGroups(List<Group> groups);
 
     /**
+     * Get user by username and hashed password
+     * @param username       username we're looking for
+     * @param hashedPassword hash of password
+     * @return {@Code List<PoulpeUser>}
+     */
+    List<PoulpeUser> getByUsernameAndPassword(String username, String hashedPassword);
+
+    /**
      * Retrieves user by its email
      * @param email to look up
      * @return retrieved {@link org.jtalks.poulpe.model.entity.PoulpeUser} instance

--- a/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/UserDao.java
+++ b/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/UserDao.java
@@ -106,4 +106,11 @@ public interface UserDao extends org.jtalks.common.model.dao.UserDao<PoulpeUser>
      */
     void save(User user);
 
+    /**
+     * Get user by username and hashed password
+     * @param username      username for search
+     * @param passwordHash  hash string of user's password
+     * @return {@link org.jtalks.poulpe.model.entity.PoulpeUser} instance or NULL if not found
+     */
+    PoulpeUser getByUsernameAndHashedPassword(String username, String passwordHash);
 }

--- a/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/hibernate/UserHibernateDao.java
+++ b/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/hibernate/UserHibernateDao.java
@@ -141,6 +141,15 @@ public class UserHibernateDao extends GenericDao<PoulpeUser> implements UserDao 
         return query.list();
     }
 
+    @Override
+    public List<PoulpeUser> getByUsernameAndPassword(String username, String hashedPassword) {
+        Query query = session().getNamedQuery("findUsersByUsernameAndHashedPassword");
+        query.setString("username", username.toLowerCase());
+        query.setString("password", hashedPassword);
+        return query.list();
+
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/hibernate/UserHibernateDao.java
+++ b/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/hibernate/UserHibernateDao.java
@@ -196,6 +196,14 @@ public class UserHibernateDao extends GenericDao<PoulpeUser> implements UserDao 
         session().flush();
     }
 
+    @Override
+    public PoulpeUser getByUsernameAndHashedPassword(String username, String passwordHash) {
+        Query query = session().getNamedQuery("findUserByUsernameAndHashedPassword");
+        query.setString("username", username);
+        query.setString("passwordHash", passwordHash);
+        return (PoulpeUser) query.uniqueResult();
+    }
+
     /**
      * Returns order of sorting by sorting request
      *

--- a/poulpe-model/src/main/resources/org/jtalks/poulpe/model/entity/User.hbm.xml
+++ b/poulpe-model/src/main/resources/org/jtalks/poulpe/model/entity/User.hbm.xml
@@ -92,6 +92,10 @@
         <![CDATA[from PoulpeUser u where u.username = :username]]>
     </query>
 
+    <query name="findUserByUsernameAndHashedPassword">
+        <![CDATA[from PoulpeUser u where u.username = :username and u.password = :passwordHash]]>
+    </query>
+
     <query name="findUsersByEmail">
         <![CDATA[from PoulpeUser u where u.email = :email]]>
     </query>

--- a/poulpe-model/src/main/resources/org/jtalks/poulpe/model/entity/User.hbm.xml
+++ b/poulpe-model/src/main/resources/org/jtalks/poulpe/model/entity/User.hbm.xml
@@ -92,8 +92,8 @@
         <![CDATA[from PoulpeUser u where u.username = :username]]>
     </query>
 
-    <query name="findUserByUsernameAndHashedPassword">
-        <![CDATA[from PoulpeUser u where u.username = :username and u.password = :passwordHash]]>
+    <query name="findUsersByUsernameAndHashedPassword">
+        <![CDATA[from PoulpeUser u where lower(u.username) = :username and u.password = :password]]>
     </query>
 
     <query name="findUsersByEmail">

--- a/poulpe-service/src/main/java/org/jtalks/poulpe/service/transactional/TransactionalUserService.java
+++ b/poulpe-service/src/main/java/org/jtalks/poulpe/service/transactional/TransactionalUserService.java
@@ -249,10 +249,17 @@ public class TransactionalUserService implements UserService {
     @Override
     public PoulpeUser authenticate(String username, String password)
             throws NotFoundException {
-        PoulpeUser poulpeUser = userDao.getByUsernameAndHashedPassword(username, password);
-        if (poulpeUser == null) throw new NotFoundException();
-        return poulpeUser;
-    }
+        List<PoulpeUser> users = userDao.getByUsernameAndPassword(username, password);
+        if (users.size() == 1) {
+            return users.get(0);
+        } else {
+            for (PoulpeUser user : users) {
+                if (user.getUsername().equals(username)) {
+                    return user;
+                }
+            }
+        }
+        throw new NotFoundException();}
 
     /**
      * {@inheritDoc}

--- a/poulpe-service/src/main/java/org/jtalks/poulpe/service/transactional/TransactionalUserService.java
+++ b/poulpe-service/src/main/java/org/jtalks/poulpe/service/transactional/TransactionalUserService.java
@@ -249,12 +249,9 @@ public class TransactionalUserService implements UserService {
     @Override
     public PoulpeUser authenticate(String username, String password)
             throws NotFoundException {
-        PoulpeUser user = getPoulpeUser(username);
-        if (user.getPassword().equals(password)) {
-            return user;
-        } else {
-            throw new NotFoundException();
-        }
+        PoulpeUser poulpeUser = userDao.getByUsernameAndHashedPassword(username, password);
+        if (poulpeUser == null) throw new NotFoundException();
+        return poulpeUser;
     }
 
     /**
@@ -274,22 +271,6 @@ public class TransactionalUserService implements UserService {
         } else {
             throw new ValidationException(Collections.singletonList("user.already_active"));
         }
-    }
-
-    private PoulpeUser getPoulpeUser(String username) throws NotFoundException {
-        UserSearchRequest searchRequest = new UserSearchRequest(true, Pages.NONE, "username", username);
-        searchRequest.setCaseSensitise(true);
-        List<PoulpeUser> users = userDao.findPoulpeUsersBySearchRequest(searchRequest);
-        if (users.size() == 1) {
-            return users.get(0);
-        } else {
-            for (PoulpeUser user : users) {
-                if (user.getUsername().equals(username)) {
-                    return user;
-                }
-            }
-        }
-        throw new NotFoundException();
     }
 
     /**

--- a/poulpe-service/src/test/java/org/jtalks/poulpe/service/transactional/TransactionalUserServiceTest.java
+++ b/poulpe-service/src/test/java/org/jtalks/poulpe/service/transactional/TransactionalUserServiceTest.java
@@ -264,64 +264,16 @@ public class TransactionalUserServiceTest{
     
     @Test
     public void authenticate() throws NotFoundException {
-        when(userDao.findPoulpeUsersBySearchRequest(any(UserSearchRequest.class)))
-                .thenReturn(Collections.singletonList(POULPE_USER));
-
+        when(userDao.getByUsernameAndHashedPassword(anyString(), anyString()))
+                .thenReturn(POULPE_USER);
         assertEquals(userService.authenticate(USERNAME, HASED_PASSWORD), POULPE_USER);
-
-        verify(userDao).findPoulpeUsersBySearchRequest(any(UserSearchRequest.class));
-        verify(userDao, never()).getByUsername(eq(USERNAME));
     }
 
-    @Test
-    public void authenticateCaseSensitise() throws NotFoundException {
-        when(userDao.findPoulpeUsersBySearchRequest(any(UserSearchRequest.class)))
-                .thenReturn(Arrays.asList(POULPE_USER, ANOTHER_USER));
-
-        assertEquals(userService.authenticate(USERNAME, HASED_PASSWORD), POULPE_USER);
-
-        verify(userDao).findPoulpeUsersBySearchRequest(any(UserSearchRequest.class));
-    }
-
-    @Test
-    public void authenticateCaseSensitise_whenUsernameNotFound() throws NotFoundException {
-        String searchUsername = StringUtils.capitalize(USERNAME);
-        when(userDao.findPoulpeUsersBySearchRequest(any(UserSearchRequest.class)))
-                .thenReturn(Arrays.asList(POULPE_USER, ANOTHER_USER));
-
-        try {
-            userService.authenticate(searchUsername, HASED_PASSWORD);
-            fail("NotFoundException should be thrown when case sensitive username is not found");
-        } catch (NotFoundException e) {
-        }
-        verify(userDao).findPoulpeUsersBySearchRequest(any(UserSearchRequest.class));
-    }
-
-    @Test
-        public void authenticate_whenUsernameNotFound() throws NotFoundException {
-        when(userDao.findPoulpeUsersBySearchRequest(any(UserSearchRequest.class)))
-                .thenReturn(Collections.<PoulpeUser>emptyList());
-
-        try {
-            userService.authenticate(USERNAME, HASED_PASSWORD);
-            fail("NotFoundException should be thrown when case insensitive username is not found");
-        } catch (NotFoundException e) {
-        }
-
-        verify(userDao).findPoulpeUsersBySearchRequest(any(UserSearchRequest.class));
-    }
-
-    @Test
-    public void authenticate_whenPasswordNotMatch() throws NotFoundException {
-        when(userDao.findPoulpeUsersBySearchRequest(any(UserSearchRequest.class)))
-                .thenReturn(Collections.singletonList(POULPE_USER));
-
-        try {
-            userService.authenticate(USERNAME, "notMatchPassword");
-            fail("NotFoundException should be thrown when provided password doesn't match required one");
-        } catch (NotFoundException e) {
-        }
-        verify(userDao).findPoulpeUsersBySearchRequest(any(UserSearchRequest.class));
+    @Test(expectedExceptions = NotFoundException.class)
+    public void authenticate_whenUsernameNotFound() throws NotFoundException {
+        when(userDao.getByUsernameAndHashedPassword(anyString(), anyString()))
+                .thenReturn(null);
+        userService.authenticate(USERNAME, HASED_PASSWORD);
     }
 
     @Test


### PR DESCRIPTION
An error occurred due to a high load on the database as a result of a request for user search when username is empty (the query looks like ... **where username like '%%'**).  The solution is to search user exactly by username and hashed password.