### PR TITLE
JC-2371 Login with empty "Username" field leads to server error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.1</version>
+        <version>3.4</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -300,7 +300,12 @@
         <artifactId>reflections</artifactId>
         <version>0.9.6</version>
       </dependency>
-
+      <dependency>
+        <groupId>io.qala.datagen</groupId>
+        <artifactId>qala-datagen</artifactId>
+        <version>1.9.2</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- Web -->
       <dependency>

--- a/poulpe-model/pom.xml
+++ b/poulpe-model/pom.xml
@@ -116,6 +116,10 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.qala.datagen</groupId>
+      <artifactId>qala-datagen</artifactId>
+    </dependency>
 
     <!-- Cache -->
     <dependency>

--- a/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/UserDao.java
+++ b/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/UserDao.java
@@ -67,6 +67,14 @@ public interface UserDao extends org.jtalks.common.model.dao.UserDao<PoulpeUser>
     List<PoulpeUser> getUsersInGroups(List<Group> groups);
 
     /**
+     * Get user by username and hashed password
+     * @param username      username we're looking for
+     * @param passwordHash  hash of password
+     * @return {@Code List<PoulpeUser>}
+     */
+    List<PoulpeUser> findUsersByUsernameAndPasswordHash(String username, String passwordHash);
+
+    /**
      * Retrieves user by its email
      * @param email to look up
      * @return retrieved {@link org.jtalks.poulpe.model.entity.PoulpeUser} instance

--- a/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/hibernate/UserHibernateDao.java
+++ b/poulpe-model/src/main/java/org/jtalks/poulpe/model/dao/hibernate/UserHibernateDao.java
@@ -141,6 +141,14 @@ public class UserHibernateDao extends GenericDao<PoulpeUser> implements UserDao 
         return query.list();
     }
 
+    @Override
+    public List<PoulpeUser> findUsersByUsernameAndPasswordHash(String username, String passwordHash) {
+        Query query = session().getNamedQuery("findUsersByUsernameAndPasswordHash");
+        query.setString("username", username);
+        query.setString("password", passwordHash);
+        return query.list();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/poulpe-model/src/main/resources/org/jtalks/poulpe/model/entity/User.hbm.xml
+++ b/poulpe-model/src/main/resources/org/jtalks/poulpe/model/entity/User.hbm.xml
@@ -92,6 +92,10 @@
         <![CDATA[from PoulpeUser u where u.username = :username]]>
     </query>
 
+    <query name="findUsersByUsernameAndPasswordHash">
+        <![CDATA[from PoulpeUser u where lower(u.username) = lower(:username) and u.password = :password]]>
+    </query>
+
     <query name="findUsersByEmail">
         <![CDATA[from PoulpeUser u where u.email = :email]]>
     </query>

--- a/poulpe-service/pom.xml
+++ b/poulpe-service/pom.xml
@@ -84,8 +84,12 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
     </dependency>
-   
-	<!-- REST dependencies -->
+    <dependency>
+      <groupId>io.qala.datagen</groupId>
+      <artifactId>qala-datagen</artifactId>
+    </dependency>
+
+    <!-- REST dependencies -->
     <dependency>
       <groupId>org.restlet.jee</groupId>
       <artifactId>org.restlet</artifactId>


### PR DESCRIPTION
An error occurred due to a high load on the database as a result of a request for user search when username is empty (where username like '%%').  The solution is to search user exactly by username and hashed password.