### PR TITLE
JC-2361 User activation in Poulpe.

### DIFF
--- a/poulpe-service/src/main/java/org/jtalks/poulpe/service/UserService.java
+++ b/poulpe-service/src/main/java/org/jtalks/poulpe/service/UserService.java
@@ -209,12 +209,12 @@ public interface UserService {
     PoulpeUser authenticate(String username, String password) throws NotFoundException;
 
     /**
-     * Activate user by user's uuid
-     * @param uuid user's uuid
-     * @throws NotFoundException if user with provided uuid does not exist
-     * @throws ValidationException if not valid uuid is provided
+     * Activate user by username
+     * @param username username
+     * @throws NotFoundException if user with provided username does not exist
+     * @throws ValidationException if not valid username is provided
      */
-    void activate(String uuid) throws NotFoundException, ValidationException;
+    void activate(String username) throws NotFoundException, ValidationException;
 
     /**
      * Registers a new user

--- a/poulpe-service/src/main/java/org/jtalks/poulpe/service/transactional/TransactionalUserService.java
+++ b/poulpe-service/src/main/java/org/jtalks/poulpe/service/transactional/TransactionalUserService.java
@@ -267,11 +267,11 @@ public class TransactionalUserService implements UserService {
      * {@inheritDoc}
      */
     @Override
-    public void activate(String uuid) throws NotFoundException, ValidationException {
-        PoulpeUser user = Validate.notNull(userDao.getByUUID(requireNotNullNorEmpty(uuid)), "User wasn't found during activation, UUID = {%s}", uuid);
+    public void activate(String username) throws NotFoundException, ValidationException {
+        PoulpeUser user = Validate.notNull(userDao.getByUsername(requireNotNullNorEmpty(username)), "User wasn't found during activation, username = {%s}", username);
         if (user.isEnabled()) throw new ValidationException(Collections.singletonList("user.already_active"));
         user.setEnabled(true);
-        userDao.save(user);
+        userDao.saveOrUpdate(user);
     }
 
     /**

--- a/poulpe-view/poulpe-web-controller/src/main/java/org/jtalks/poulpe/web/controller/rest/ActivationServerResource.java
+++ b/poulpe-view/poulpe-web-controller/src/main/java/org/jtalks/poulpe/web/controller/rest/ActivationServerResource.java
@@ -31,9 +31,9 @@ public class ActivationServerResource extends CommonServerResource implements Ac
 
     @Override
     public Representation activate() {
-        String uuid = getQueryValue("uuid");
+        String username = getQueryValue("username");
         try {
-            userService.activate(uuid);
+            userService.activate(username);
         } catch (NotFoundException e) {
             getResponse().setStatus(Status.CLIENT_ERROR_NOT_FOUND);
             return new EmptyRepresentation();


### PR DESCRIPTION
Since we moved poulpe to its own database, we can't find users by UUID that has been created not in the poulpe. So, user activation requires username instead of UUID